### PR TITLE
Uptime endpoint

### DIFF
--- a/app/controllers/uptime_controller.rb
+++ b/app/controllers/uptime_controller.rb
@@ -1,0 +1,5 @@
+class UptimeController < ApplicationController
+  def heartbeat
+    head :ok
+  end
+end

--- a/bin/host_setup
+++ b/bin/host_setup
@@ -14,8 +14,8 @@ if [ "$INPUT" = "--worktree" ]; then
 	bundle config set --local path vendor/bundle
 	echo "================ Installing Gems ==================="
 	bundle install
-	echo "================ parsing gem yard docs ==================="
-	bundle exec yard gems
+	# echo "================ parsing gem yard docs ==================="
+	# bundle exec yard gems
 	echo "================ setup Annotations ===================="
 	bundle exec rails generate annotate:install
 	if [ -f "spec/spec_helper.rb" ]; then

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'users/index'
   get '/search', to: 'search#index'
   get 'authors/:id', to: 'users#author_show'
+  get 'heartbeat', to: 'uptime#heartbeat'
 
   get 'author-spotlight', to: 'users#author_spotlight'
 


### PR DESCRIPTION
add a barebones heartbeat endpoint to point my uptime bot at. Reduces data transfer and remove any need for db querying.