### PR TITLE
Updates 03 25 - image downloading fix

### DIFF
--- a/app/components/books/gallery_card_component.html.erb
+++ b/app/components/books/gallery_card_component.html.erb
@@ -8,6 +8,10 @@
 >
 
   <div class="gallery-card-details">
+    <% if book.cover_image.attached? %>
+      <%= image_tag book.cover_image.variant(resize_to_limit: [250, 250]) %>
+    <% end %>
+
     <p class="title is-4 mb-2">
       <%= book.title %>
     </p>
@@ -44,6 +48,7 @@
         <%= book.paperback_price %>
       </p>
     <% end %>
+    
 
     <p>
       <strong>Blurb:</strong>

--- a/app/components/books/gallery_card_component.html.erb
+++ b/app/components/books/gallery_card_component.html.erb
@@ -7,7 +7,7 @@
   data-book-title="<%= book.title %>"
 >
 
-  <div class="gallery-card-details">
+  <div class="gallery-card-details has-text-centered">
     <% if book.cover_image.attached? %>
       <%= image_tag book.cover_image.variant(resize_to_limit: [250, 250]) %>
     <% end %>
@@ -15,44 +15,45 @@
     <p class="title is-4 mb-2">
       <%= book.title %>
     </p>
-    <div class="pt-2" style="border-top: 1px solid black;">
-      <% book.tags.each do |tag| %>
-        <span class="tag is-<%= tag.color_class %>"><%= tag.name.capitalize %></span>
+
+    <div class="has-text-left">
+      <div class="pt-2" style="border-top: 1px solid black;">
+        <% book.tags.each do |tag| %>
+          <span class="tag is-<%= tag.color_class %>"><%= tag.name.capitalize %></span>
+        <% end %>
+      </div>
+      <% if book.series %>
+        <p>
+          <strong>Series:</strong>
+          <%= book.series.name %>
+        </p>
+
+        <p>
+          <strong>Series Number:</strong>
+          <%= book.position %>
+        </p>
       <% end %>
+
+      <p>
+        <strong>E-book Price:</strong>
+        <% if book.free? %>
+          Free
+        <% else %>
+          <%= book.display_price %>
+        <% end %>
+      </p>
+
+      <% if book.paperback_price.present? %>
+        <p>
+          <strong>Paperback Price:</strong>
+          <%= book.paperback_price %>
+        </p>
+      <% end %>
+
+      <p>
+        <strong>Blurb:</strong>
+        <%= book.one_liner_blurb %>
+      </p>
     </div>
-
-    <% if book.series %>
-      <p>
-        <strong>Series:</strong>
-        <%= book.series.name %>
-      </p>
-
-      <p>
-        <strong>Series Number:</strong>
-        <%= book.position %>
-      </p>
-    <% end %>
-
-    <p>
-      <strong>E-book Price:</strong>
-      <% if book.free? %>
-        Free
-      <% else %>
-        <%= book.display_price %>
-      <% end %>
-    </p>
-
-    <% if book.paperback_price.present? %>
-      <p>
-        <strong>Paperback Price:</strong>
-        <%= book.paperback_price %>
-      </p>
-    <% end %>
-    
-
-    <p>
-      <strong>Blurb:</strong>
-      <%= book.one_liner_blurb %>
-    </p>
   </div>
 </div>

--- a/app/components/books/gallery_compact_component.html.erb
+++ b/app/components/books/gallery_compact_component.html.erb
@@ -6,7 +6,7 @@
   data-action="click->books--card#showModal"
 >
   <% if book.cover_image.attached? %>
-    <%= image_tag book.cover_image, loading: "lazy" %>
+    <%= image_tag book.cover_image.variant(resize_to_limit: [500, 500]), loading: "lazy" %>
   <% end %>
   <div>
     <% book.tags.each do |tag| %>

--- a/app/components/books/gallery_quick_view_component.html.erb
+++ b/app/components/books/gallery_quick_view_component.html.erb
@@ -60,7 +60,7 @@
     </div>
 
     <% if book.cover_image.attached? %>
-      <%= image_tag book.cover_image, class: "mb-2", loading: "lazy" %>
+      <%= image_tag book.cover_image.variant(resize_to_limit: [500, 500]), class: "mb-2", loading: "lazy" %>
     <% end %>
 
     <a

--- a/app/components/books/gallery_quick_view_component.html.erb
+++ b/app/components/books/gallery_quick_view_component.html.erb
@@ -59,9 +59,11 @@
       <% end %>
     </div>
 
-    <% if book.cover_image.attached? %>
+    <div class="has-text-centered">
+      <% if book.cover_image.attached? %>
       <%= image_tag book.cover_image.variant(resize_to_limit: [500, 500]), class: "mb-2", loading: "lazy" %>
     <% end %>
+    </div>
 
     <a
       href="<%= book.primary_link %>"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -45,6 +45,15 @@ module Admin
       redirect_to(new_user_invitation_url)
     end
 
+    def create
+      super
+      requested_resource.process_photo_variants
+    end
+
+    def update
+      super
+      requested_resource.process_photo_variants
+    end
     # def resource_params
     #   params.require(:user).permit(:about, :spotlight, :email, :name, :role, :facebook_url, :instagram_url, :tiktok_url, :photo, :website_url, book_ids: [])
     # end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -56,6 +56,7 @@ class BooksController < ApplicationController
     @show_series = params[:series]
     respond_to do |format|
       if @book.save
+        @book.process_image_variants
         format.html { redirect_to admin_books_path, notice: 'Book was successfully created.' }
         format.json { render :show, status: :created, location: @book }
       else
@@ -78,6 +79,7 @@ class BooksController < ApplicationController
     @show_series = params[:series]
     respond_to do |format|
       if @book.update(book_params)
+        @book.process_image_variants
         format.html { redirect_to admin_book_url(@book), notice: 'Book was successfully updated.' }
         format.json { render :show, status: :ok, location: @book }
       else

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,5 +1,5 @@
 class BusinessesController < ApplicationController
-  before_action :set_business, only: %i[ show edit update destroy ]
+  before_action :set_business, only: %i[show edit update destroy]
 
   # GET /businesses or /businesses.json
   def index
@@ -7,8 +7,7 @@ class BusinessesController < ApplicationController
   end
 
   # GET /businesses/1 or /businesses/1.json
-  def show
-  end
+  def show; end
 
   # GET /businesses/new
   def new
@@ -16,8 +15,7 @@ class BusinessesController < ApplicationController
   end
 
   # GET /businesses/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /businesses or /businesses.json
   def create
@@ -25,7 +23,8 @@ class BusinessesController < ApplicationController
 
     respond_to do |format|
       if @business.save
-        format.html { redirect_to business_url(@business), notice: "Business was successfully created." }
+        @business.process_logo_variants
+        format.html { redirect_to business_url(@business), notice: 'Business was successfully created.' }
         format.json { render :show, status: :created, location: @business }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -38,7 +37,8 @@ class BusinessesController < ApplicationController
   def update
     respond_to do |format|
       if @business.update(business_params)
-        format.html { redirect_to business_url(@business), notice: "Business was successfully updated." }
+        @business.process_logo_variants
+        format.html { redirect_to business_url(@business), notice: 'Business was successfully updated.' }
         format.json { render :show, status: :ok, location: @business }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -52,19 +52,20 @@ class BusinessesController < ApplicationController
     @business.destroy
 
     respond_to do |format|
-      format.html { redirect_to businesses_url, notice: "Business was successfully destroyed." }
+      format.html { redirect_to businesses_url, notice: 'Business was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_business
-      @business = Business.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def business_params
-      params.require(:business).permit(:name, :website_url)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_business
+    @business = Business.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def business_params
+    params.require(:business).permit(:name, :website_url)
+  end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -50,8 +50,6 @@ class Book < ApplicationRecord
   belongs_to :series, optional: true
   has_one_attached :cover_image
 
-  after_save :process_image_variants, if: -> { cover_image.attached? }
-
   scope :filter_by_genre, lambda { |genre_ids|
     where(id:
       Book.joins(:genres)
@@ -85,9 +83,9 @@ class Book < ApplicationRecord
     tags.select { |tag| tag.name.downcase == 'free' }.size == 1
   end
 
-  private
-
   def process_image_variants
+    return unless cover_image.attached?
+
     cover_image.variant(resize_to_limit: [250, 250]).processed
     cover_image.variant(resize_to_limit: [500, 500]).processed
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -50,6 +50,8 @@ class Book < ApplicationRecord
   belongs_to :series, optional: true
   has_one_attached :cover_image
 
+  after_save :process_image_variants, if: -> { cover_image.attached? }
+
   scope :filter_by_genre, lambda { |genre_ids|
     where(id:
       Book.joins(:genres)
@@ -81,5 +83,12 @@ class Book < ApplicationRecord
 
   def free?
     tags.select { |tag| tag.name.downcase == 'free' }.size == 1
+  end
+
+  private
+
+  def process_image_variants
+    cover_image.variant(resize_to_limit: [250, 250]).processed
+    cover_image.variant(resize_to_limit: [500, 500]).processed
   end
 end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -13,10 +13,6 @@ class Business < ApplicationRecord
   validates :name, presence: true
   validates :website_url, presence: true
 
-  after_save :process_logo_variants, if: -> { logo.attached? }
-
-  private
-
   def process_logo_variants
     logo.variants(resize_to_limit: [400, 400]).processed
   end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -12,4 +12,12 @@ class Business < ApplicationRecord
   has_one_attached :logo_image
   validates :name, presence: true
   validates :website_url, presence: true
+
+  after_save :process_logo_variants, if: -> { logo.attached? }
+
+  private
+
+  def process_logo_variants
+    logo.variants(resize_to_limit: [400, 400]).processed
+  end
 end

--- a/app/models/promo.rb
+++ b/app/models/promo.rb
@@ -24,9 +24,7 @@ class Promo < ApplicationRecord
                      .or(where(['end_date = :today', { today: Date.today }]))
                  }
 
-  private
-
   def process_banner_variants
-    banner.variant(resize_to_limit: [1500, 400]).processed
+    banner.variant(resize_to_limit: [1500, 400]).process
   end
 end

--- a/app/models/promo.rb
+++ b/app/models/promo.rb
@@ -11,6 +11,9 @@
 #
 class Promo < ApplicationRecord
   has_one_attached :banner
+
+  after_save :process_banner_variants, if: -> { banner.attached? }
+
   scope :next_up, lambda {
                     where(['start_date > :today', { today: Date.today }])
                       .order(:start_date)
@@ -20,4 +23,10 @@ class Promo < ApplicationRecord
                      .or(where(['start_date = :today', { today: Date.today }]))
                      .or(where(['end_date = :today', { today: Date.today }]))
                  }
+
+  private
+
+  def process_banner_variants
+    banner.variant(resize_to_limit: [1500, 400]).processed
+  end
 end

--- a/app/models/promo.rb
+++ b/app/models/promo.rb
@@ -12,8 +12,6 @@
 class Promo < ApplicationRecord
   has_one_attached :banner
 
-  after_save :process_banner_variants, if: -> { banner.attached? }
-
   scope :next_up, lambda {
                     where(['start_date > :today', { today: Date.today }])
                       .order(:start_date)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,6 @@ class User < ApplicationRecord
   has_many :series, dependent: :destroy, foreign_key: 'author_id'
   has_one_attached :photo
 
-  after_save :process_photo_variants, if: -> { photo.attached? }
-
   # authors that have been sent invitations but havent logged in and filled out their profile will have an empty name
   scope :valid_users, -> { where(name: '').invert_where }
   scope :in_the_spotlight, -> { where(spotlight: true) }
@@ -65,9 +63,9 @@ class User < ApplicationRecord
     ['name']
   end
 
-  private
-
   def process_photo_variants
+    return unless photo.attached?
+
     photo.variant(resize_to_limit: [200, 200]).processed
     photo.variant(resize_to_limit: [500, 500]).processed
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,8 @@ class User < ApplicationRecord
   has_many :series, dependent: :destroy, foreign_key: 'author_id'
   has_one_attached :photo
 
+  after_save :process_photo_variants, if: -> { photo.attached? }
+
   # authors that have been sent invitations but havent logged in and filled out their profile will have an empty name
   scope :valid_users, -> { where(name: '').invert_where }
   scope :in_the_spotlight, -> { where(spotlight: true) }
@@ -61,5 +63,12 @@ class User < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     ['name']
+  end
+
+  private
+
+  def process_photo_variants
+    photo.variant(resize_to_limit: [200, 200]).processed
+    photo.variant(resize_to_limit: [500, 500]).processed
   end
 end

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -40,7 +40,7 @@
   </p>
 
   <% if book.cover_image.attached? %>
-    <%= image_tag book.cover_image %>
+    <%= image_tag book.cover_image.variant(resize_to_limit: [500, 500]) %>
   <% end %>
 
 </div>

--- a/app/views/businesses/_business.html.erb
+++ b/app/views/businesses/_business.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="business" id="<%= dom_id business %>" class="tile is-parent is-vertical is-4 is-align-items-center">
   <% if business.logo_image.attached? %>
-    <%= image_tag business.logo_image, size: "400" %>
+    <%= image_tag business.logo_image.variant(resize_to_limit: [400, 400]), size: "400" %>
   <% end %>
 
   <h1 class="title my-2 ">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,9 +66,9 @@
     </nav>
     <div class="container is-flex is-justify-content-center mb-4">
       <% if Promo.active.any? && Promo.active.first.banner.attached? %>
-        <%= image_tag Promo.active.first.banner %>
+        <%= image_tag Promo.active.first.banner.variant(resize_to_limit: [1500, 400]) %>
       <% elsif Promo.next_up.any? && Promo.next_up.first.banner.attached? %>
-        <%= image_tag Promo.next_up.first.banner %>
+        <%= image_tag Promo.next_up.first.banner.variant(resize_to_limit: [1500, 400]) %>
       <% end %>
 
     </div>

--- a/app/views/users/author_show.html.erb
+++ b/app/views/users/author_show.html.erb
@@ -5,13 +5,13 @@
       <a href="<%= @author.website_url %>" target="_blank" class="is-size-4">Visit my website!</a>
     </div>
     <div>
-      <% unless @author.facebook_url.empty? %>
+      <% unless @author.facebook_url.nil? %>
         <a href="<%= @author.facebook_url %>" class="mr-2"><i class="fa-brands fa-facebook fa-2x"></i></a>
       <% end %>
-      <% unless @author.instagram_url.empty? %>
+      <% unless @author.instagram_url.nil? %>
         <a href="<%= @author.instagram_url %>" class="mr-2"><i class="fa-brands fa-instagram fa-2x"></i></a>
       <% end %>
-      <% unless @author.tiktok_url.empty? %>
+      <% unless @author.tiktok_url.nil? %>
         <a href="<%= @author.tiktok_url %>"><i class="fa-brands fa-tiktok fa-2x"></i></a>
       <% end %>
     </div>
@@ -19,7 +19,7 @@
   <div class="columns">
     <% if @author.photo.attached? %>
       <div class="column has-text-centered">
-        <%= image_tag @author.photo, size: "500" %>
+        <%= image_tag @author.photo.variant(resize_to_limit: [500, 500]), size: "500" %>
       </div>
     <% end %>
     <div class="column">

--- a/app/views/users/author_spotlight.html.erb
+++ b/app/views/users/author_spotlight.html.erb
@@ -5,40 +5,42 @@
   <% @authors.each do |author| %>
     <section class="section" id="author-<%= author.id %>">
       <%# author photo + social links %>
-      <div class="columns">
-        <% if author.photo.attached? %>
-        <div class="column is-one-fifth">
-          <%= image_tag author.photo, size: "200" %>
-        </div>
-      <% end %>
+      <a style=text-decoration: none; href="/authors/<%= author.id %>">
+        <div class="columns">
+          <% if author.photo.attached? %>
+            <div class="column">
+              <%= image_tag author.photo.variant(resize_to_limit: [200, 200]), size: "200" %>
+            </div>
+          <% end %>
 
-      <div class="column">
-        <h2 class="is-size-4 has-text-weight-bold"><%= author.name %></h2>
+          <div class="column">
+            <h2 class="is-size-4 has-text-weight-bold"><%= author.name %></h2>
 
-        <div class="mr-2 mb-2">
-          <a href="<%= author.website_url %>" target="_blank" class="is-size-4">Visit my website!</a>
+            <div class="mr-2 mb-2">
+              <a href="<%= author.website_url %>" target="_blank" class="is-size-4">Visit my website!</a>
+            </div>
+            <div>
+              <% unless author.facebook_url.nil? %>
+                <a href="<%= author.facebook_url %>" class="mr-2"><i class="fa-brands fa-facebook fa-2x"></i></a>
+              <% end %>
+              <% unless author.instagram_url.nil? %>
+                <a href="<%= author.instagram_url %>" class="mr-2"><i class="fa-brands fa-instagram fa-2x"></i></a>
+              <% end %>
+              <% unless author.tiktok_url.nil? %>
+                <a href="<%= author.tiktok_url %>"><i class="fa-brands fa-tiktok fa-2x"></i></a>
+              <% end %>
+            </div>
+          </div>
         </div>
-        <div>
-          <% unless author.facebook_url.nil? %>
-            <a href="<%= author.facebook_url %>" class="mr-2"><i class="fa-brands fa-facebook fa-2x"></i></a>
-          <% end %>
-          <% unless author.instagram_url.nil? %>
-            <a href="<%= author.instagram_url %>" class="mr-2"><i class="fa-brands fa-instagram fa-2x"></i></a>
-          <% end %>
-          <% unless author.tiktok_url.nil? %>
-            <a href="<%= author.tiktok_url %>"><i class="fa-brands fa-tiktok fa-2x"></i></a>
-          <% end %>
-        </div>
-      </div>
-      </div>
+      </a>
       <%# book list %>
       <h3 class="subtitle is-3">Books</h3>
-  <div class="tile is-ancestor is-flex-wrap-wrap">
-    <% Book.promo_active_per_author(author.id).series_ordered.each do |book| %>
-      <%= render(Books::GalleryCompactComponent.new(book: book)) %>
-      <%= render(Books::GalleryQuickViewComponent.new(book: book)) %>
-    <% end %>
-  </div
+      <div class="tile is-ancestor is-flex-wrap-wrap">
+        <% Book.promo_active_per_author(author.id).series_ordered.each do |book| %>
+          <%= render(Books::GalleryCompactComponent.new(book: book)) %>
+          <%= render(Books::GalleryQuickViewComponent.new(book: book)) %>
+        <% end %>
+      </div>
       <%# divider %>
       <br class="width-full">
     </section>

--- a/app/views/users/author_spotlight.html.erb
+++ b/app/views/users/author_spotlight.html.erb
@@ -19,13 +19,13 @@
           <a href="<%= author.website_url %>" target="_blank" class="is-size-4">Visit my website!</a>
         </div>
         <div>
-          <% unless author.facebook_url.empty? %>
+          <% unless author.facebook_url.nil? %>
             <a href="<%= author.facebook_url %>" class="mr-2"><i class="fa-brands fa-facebook fa-2x"></i></a>
           <% end %>
-          <% unless author.instagram_url.empty? %>
+          <% unless author.instagram_url.nil? %>
             <a href="<%= author.instagram_url %>" class="mr-2"><i class="fa-brands fa-instagram fa-2x"></i></a>
           <% end %>
-          <% unless author.tiktok_url.empty? %>
+          <% unless author.tiktok_url.nil? %>
             <a href="<%= author.tiktok_url %>"><i class="fa-brands fa-tiktok fa-2x"></i></a>
           <% end %>
         </div>

--- a/lib/tasks/process_image_variants.rake
+++ b/lib/tasks/process_image_variants.rake
@@ -1,0 +1,24 @@
+task process_image_variants: :environment do
+  books = Book.with_attached_cover_image.joins(:cover_image_attachment)
+  authors = User.with_attached_photo.joins(:photo_attachment)
+  promos = Promo.with_attached_banner.joins(:banner_attachment)
+  businesses = Business.with_attached_logo_image.joins(:logo_image_attachment)
+
+  books.each do |book|
+    book.cover_image.variant(resize_to_limit: [250, 250]).processed
+    book.cover_image.variant(resize_to_limit: [500, 500]).processed
+  end
+
+  authors.each do |author|
+    author.photo.variant(resize_to_limit: [200, 200]).processed
+    author.photo.variant(resize_to_limit: [500, 500]).processed
+  end
+
+  promos.each do |promo|
+    promo.banner.variant(resize_to_limit: [1500, 400]).processed
+  end
+
+  businesses.each do |biz|
+    biz.logo_image.variant(resize_to_limit: [400, 400]).processed
+  end
+end

--- a/lib/tasks/process_image_variants.rake
+++ b/lib/tasks/process_image_variants.rake
@@ -4,21 +4,45 @@ task process_image_variants: :environment do
   promos = Promo.with_attached_banner.joins(:banner_attachment)
   businesses = Business.with_attached_logo_image.joins(:logo_image_attachment)
 
+  coverless_books = []
   books.each do |book|
     book.cover_image.variant(resize_to_limit: [250, 250]).processed
     book.cover_image.variant(resize_to_limit: [500, 500]).processed
+  rescue ActiveStorage::FileNotFoundError
+    coverless_books.push(book.title)
   end
 
+  photoless_authors = []
   authors.each do |author|
     author.photo.variant(resize_to_limit: [200, 200]).processed
     author.photo.variant(resize_to_limit: [500, 500]).processed
+  rescue ActiveStorage::FileNotFoundError
+    photoless_authors.push(author.name)
   end
 
+  bannerless_promos = []
   promos.each do |promo|
     promo.banner.variant(resize_to_limit: [1500, 400]).processed
+  rescue ActiveStorage::FileNotFoundError
+    bannerless_promos.push(promo.title)
   end
 
+  logoless_businesses = []
   businesses.each do |biz|
     biz.logo_image.variant(resize_to_limit: [400, 400]).processed
+  rescue ActiveStorage::FileNotFoundError
+    logoless_businesses.push(biz.name)
   end
+
+  puts 'Books without a cover:' unless coverless_books.empty?
+  coverless_books.each { |title| puts "- #{title}" }
+
+  puts 'Authors without a photo' unless photoless_authors.empty?
+  photoless_authors.each { |author| puts "- #{author}" }
+
+  puts 'Promos without a banner' unless bannerless_promos.empty?
+  bannerless_promos.each { |promo| puts "- #{promo}" }
+
+  puts 'Businesses without a logo' unless logoless_businesses.empty?
+  logoless_businesses.each { |biz| puts "- #{biz}" }
 end


### PR DESCRIPTION
Images were too large and downloading all of them caused a huge slowdown. Setup all incoming images to get processed into differing variant sizes and applied those to the relevant positions.

Gallery gets the smallest images so they use the least amount of data.